### PR TITLE
Use secrets for GoodWe and Passbolt manifests

### DIFF
--- a/README-Despliegue-Modulares.md
+++ b/README-Despliegue-Modulares.md
@@ -35,6 +35,7 @@ Los manifiestos viven en:
 ```
 - Construye desde: `/backend/gateways/goodwe/`
 - Aplica: `/k8s/gateways/gateway-goodwe.yaml`
+- Requiere `Secret`: `secrets/gateway-goodwe-secret.yaml`
 
 ### 🔹 Proxy OpenAI (IA externa temporal)
 ```bash

--- a/README-tools.md
+++ b/README-tools.md
@@ -26,8 +26,7 @@ Contiene los manifiestos que despliegan:
 - Ingress: `http://passbolt.emiliomoro.local`
 
 ### Configuración
-- Variables de entorno definidas directamente en el deployment
-- Pendiente: uso de `ConfigMap` y `Secrets`
+- Las variables de entorno se cargan desde un `Secret`
 
 ---
 
@@ -65,6 +64,14 @@ Contiene los manifiestos que despliegan:
 ```
 
 Manifiesto: `k8s/tools/passbolt-rustdesk.yaml`
+
+### Secrets requeridos
+Edita los archivos en `secrets/` con tus credenciales y aplícalos antes del despliegue:
+
+```bash
+kubectl apply -f secrets/gateway-goodwe-secret.yaml
+kubectl apply -f secrets/passbolt-rustdesk-secret.yaml
+```
 
 ---
 

--- a/gateway-goodwe.yaml
+++ b/gateway-goodwe.yaml
@@ -18,13 +18,9 @@ spec:
           image: gateway-goodwe:latest
           ports:
             - containerPort: 8001
-          env:
-            - name: SEMS_USER
-              value: "pedropelaezcatala@gmail.com"
-            - name: SEMS_PASS
-              value: "Goodwe2018"
-            - name: PLANT_ID
-              value: "95048ESU225W0194"
+          envFrom:
+            - secretRef:
+                name: gateway-goodwe-secret
 ---
 apiVersion: v1
 kind: Service

--- a/passbolt-rustdesk.yaml
+++ b/passbolt-rustdesk.yaml
@@ -28,27 +28,9 @@ spec:
       containers:
         - name: passbolt
           image: passbolt/passbolt:latest-ce
-          env:
-            - name: APP_FULL_BASE_URL
-              value: "http://passbolt.emiliomoro.local"
-            - name: DATASOURCES_DEFAULT_HOST
-              value: "postgresql-service"
-            - name: DATASOURCES_DEFAULT_USERNAME
-              value: "admin"
-            - name: DATASOURCES_DEFAULT_PASSWORD
-              value: "secret"
-            - name: DATASOURCES_DEFAULT_DATABASE
-              value: "centraldb"
-            - name: EMAIL_DEFAULT_FROM
-              value: "admin@yatelomiro.com"
-            - name: EMAIL_TRANSPORT_DEFAULT_HOST
-              value: "smtp.dondominio.com"
-            - name: EMAIL_TRANSPORT_DEFAULT_PORT
-              value: "587"
-            - name: EMAIL_TRANSPORT_DEFAULT_USERNAME
-              value: "admin@yatelomiro.com"
-            - name: EMAIL_TRANSPORT_DEFAULT_PASSWORD
-              value: "p15d)mYS528(rU"
+          envFrom:
+            - secretRef:
+                name: passbolt-rustdesk-secret
           ports:
             - containerPort: 80
           volumeMounts:

--- a/secrets/gateway-goodwe-secret.yaml
+++ b/secrets/gateway-goodwe-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gateway-goodwe-secret
+  namespace: central-platform
+type: Opaque
+stringData:
+  SEMS_USER: "CHANGE_ME"
+  SEMS_PASS: "CHANGE_ME"
+  PLANT_ID: "CHANGE_ME"

--- a/secrets/passbolt-rustdesk-secret.yaml
+++ b/secrets/passbolt-rustdesk-secret.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: passbolt-rustdesk-secret
+  namespace: central-platform
+type: Opaque
+stringData:
+  APP_FULL_BASE_URL: "http://passbolt.emiliomoro.local"
+  DATASOURCES_DEFAULT_HOST: "postgresql-service"
+  DATASOURCES_DEFAULT_USERNAME: "admin"
+  DATASOURCES_DEFAULT_PASSWORD: "CHANGE_ME"
+  DATASOURCES_DEFAULT_DATABASE: "centraldb"
+  EMAIL_DEFAULT_FROM: "admin@yatelomiro.com"
+  EMAIL_TRANSPORT_DEFAULT_HOST: "smtp.dondominio.com"
+  EMAIL_TRANSPORT_DEFAULT_PORT: "587"
+  EMAIL_TRANSPORT_DEFAULT_USERNAME: "admin@yatelomiro.com"
+  EMAIL_TRANSPORT_DEFAULT_PASSWORD: "CHANGE_ME"


### PR DESCRIPTION
## Summary
- switch gateway-goodwe deployment to pull env vars from a secret
- switch passbolt container to load env vars from a secret
- add example secret manifests
- document secret creation in README files

## Testing
- `git status --short`