### PR TITLE
Fix psql admin connection in init scripts

### DIFF
--- a/init-create-postgres-db.sh
+++ b/init-create-postgres-db.sh
@@ -5,6 +5,16 @@
 
 set -e
 
+# Use configured user or default to the one defined in the PostgreSQL
+# deployment. When the script is executed manually the POSTGRES_USER
+# variable might be empty, causing `psql` to try to connect as the
+# current system user (usually `root`). This results in the error
+# "role \"root\" does not exist".  Defaulting here avoids that issue.
+POSTGRES_USER="${POSTGRES_USER:-admin}"
+# Administrative commands must connect to an existing database. Use the
+# default 'postgres' database unless overridden.
+POSTGRES_ADMIN_DB="${POSTGRES_ADMIN_DB:-postgres}"
+
 NAMESPACE="central-platform"
 DB_NAME="centraldb"
 POD=$(kubectl get pod -n $NAMESPACE -l app=postgresql -o jsonpath="{.items[0].metadata.name}")
@@ -15,13 +25,13 @@ if [ -z "$POD" ]; then
 fi
 
 echo "🔍 Verificando existencia de la base de datos '$DB_NAME'..."
-DB_EXISTS=$(kubectl exec -n $NAMESPACE "$POD" -- bash -c "psql -U \"$POSTGRES_USER\" -tAc \"SELECT 1 FROM pg_database WHERE datname = '$DB_NAME';\"")
+DB_EXISTS=$(kubectl exec -n $NAMESPACE "$POD" -- bash -c "psql -U \"$POSTGRES_USER\" -d \"$POSTGRES_ADMIN_DB\" -tAc \"SELECT 1 FROM pg_database WHERE datname = '$DB_NAME';\"")
 
 if [ "$DB_EXISTS" = "1" ]; then
   echo "✅ La base de datos '$DB_NAME' ya existe."
 else
   echo "🆕 Creando base de datos '$DB_NAME'..."
-  kubectl exec -n $NAMESPACE "$POD" -- bash -c "psql -U \"$POSTGRES_USER\" -c \"CREATE DATABASE $DB_NAME;\""
+  kubectl exec -n $NAMESPACE "$POD" -- bash -c "psql -U \"$POSTGRES_USER\" -d \"$POSTGRES_ADMIN_DB\" -c \"CREATE DATABASE $DB_NAME;\""
   echo "✅ Base de datos '$DB_NAME' creada."
 fi
 

--- a/init-postgres-schema.sh
+++ b/init-postgres-schema.sh
@@ -5,6 +5,15 @@
 
 set -e
 
+# Ensure the user matches the credentials configured in the PostgreSQL
+# deployment. Without an explicit value the script may attempt to
+# authenticate as the current system user and fail with a "role does not
+# exist" error.
+POSTGRES_USER="${POSTGRES_USER:-admin}"
+# Administrative commands must connect to an existing database. Use the
+# default 'postgres' database unless overridden.
+POSTGRES_ADMIN_DB="${POSTGRES_ADMIN_DB:-postgres}"
+
 NAMESPACE="central-platform"
 DB_NAME="centraldb"
 POD=$(kubectl get pod -n $NAMESPACE -l app=postgresql -o jsonpath="{.items[0].metadata.name}")
@@ -15,12 +24,12 @@ if [ -z "$POD" ]; then
 fi
 
 echo "🔍 Verificando existencia de la base de datos '$DB_NAME'..."
-DB_EXISTS=$(kubectl exec -n $NAMESPACE "$POD" -- bash -c "psql -U \"$POSTGRES_USER\" -tAc \"SELECT 1 FROM pg_database WHERE datname = '$DB_NAME';\"")
+DB_EXISTS=$(kubectl exec -n $NAMESPACE "$POD" -- bash -c "psql -U \"$POSTGRES_USER\" -d \"$POSTGRES_ADMIN_DB\" -tAc \"SELECT 1 FROM pg_database WHERE datname = '$DB_NAME';\"")
 
 if [ "$DB_EXISTS" = "1" ]; then
   echo "✅ La base de datos '$DB_NAME' ya existe."
 else
   echo "🆕 Creando base de datos '$DB_NAME'..."
-  kubectl exec -n $NAMESPACE "$POD" -- bash -c "psql -U \"$POSTGRES_USER\" -c \"CREATE DATABASE $DB_NAME;\""
+  kubectl exec -n $NAMESPACE "$POD" -- bash -c "psql -U \"$POSTGRES_USER\" -d \"$POSTGRES_ADMIN_DB\" -c \"CREATE DATABASE $DB_NAME;\""
   echo "✅ Base de datos '$DB_NAME' creada."
 fi


### PR DESCRIPTION
## Summary
- set `POSTGRES_ADMIN_DB` so scripts connect to an existing database
- use this database when verifying/creating `centraldb`

## Testing
- `bash -n init-create-postgres-db.sh`
- `bash -n init-postgres-schema.sh`
