### PR TITLE
Fix sync script to apply nested manifests

### DIFF
--- a/03-sync-manifests.sh
+++ b/03-sync-manifests.sh
@@ -67,11 +67,15 @@ for CATEGORY in frontend backend gateways ia tools ingress databases; do
   SUBDIR="$DST_DIR/$CATEGORY"
   if [ -d "$SUBDIR" ]; then
     echo "📂 Procesando: $CATEGORY"
-    for FILE in "$SUBDIR"/*.yaml; do
-      [ -f "$FILE" ] || continue
-      echo "   ↪ Aplicando: $(basename "$FILE")"
-      kubectl apply -f "$FILE" || echo "❌ Error aplicando $FILE"
-    done
+    FILES=$(find "$SUBDIR" -type f -name '*.yaml')
+    if [ -z "$FILES" ]; then
+      echo "   ⚠️  No se encontraron manifiestos en $SUBDIR"
+    else
+      for FILE in $FILES; do
+        echo "   ↪ Aplicando: $(basename "$FILE")"
+        kubectl apply -f "$FILE" || echo "❌ Error aplicando $FILE"
+      done
+    fi
   fi
   echo ""
 done


### PR DESCRIPTION
## Summary
- improve the sync script so nested manifests (e.g. frontend/admin) are applied
- warn when no yaml files are found for a category

## Testing
- `bash -n 03-sync-manifests.sh`