### PR TITLE
Fix K8s pods stuck with ImagePullBackOff

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ http://rustdesk.emiliomoro.local  → RustDesk Web
 ## 🧼 Tips y recomendaciones
 - Reinicia sesión tras ejecutar `01-bootstrap.sh`
 - Si ves `ImagePullBackOff`, ejecuta `07-import-images.sh`
+- Comprueba que en tus YAML se indique `imagePullPolicy: IfNotPresent` para los
+  contenedores locales, evitando que Kubernetes intente descargar desde Docker
+  Hub en cada despliegue.
 - Usa `11-cluster-admin.sh` como panel de control principal
 - Personaliza los valores de entorno (`.env`, variables) según tu infraestructura
 

--- a/alerts.yaml
+++ b/alerts.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: alerts
           image: backend-alerts:latest
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3001
           env:

--- a/api-rest.yaml
+++ b/api-rest.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: api-rest
           image: backend-api:latest
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000
           env:

--- a/frontend-facit.yaml
+++ b/frontend-facit.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: frontend-facit
           image: frontend:latest
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80
 ---

--- a/frontend-fyr.yaml
+++ b/frontend-fyr.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: frontend-fyr
           image: frontend-fyr:latest
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80
 ---

--- a/gateway-goodwe.yaml
+++ b/gateway-goodwe.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: gateway-goodwe
           image: gateway-goodwe:latest
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8001
           env:

--- a/gateway-openai.yaml
+++ b/gateway-openai.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: openai-proxy
           image: openai-proxy:latest
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8010
           env:

--- a/gateway-t301.yaml
+++ b/gateway-t301.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: gateway-t301
           image: gateway-t301:latest
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9988
           env:

--- a/websocket.yaml
+++ b/websocket.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: websocket
           image: backend-websocket:latest
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000
           env:


### PR DESCRIPTION
## Summary
- avoid pulling images from Docker Hub by default
- clarify README instructions

## Testing
- `git status --short`
