### PR TITLE
Fix postgres init scripts using container env vars

### DIFF
--- a/init-create-postgres-db.sh
+++ b/init-create-postgres-db.sh
@@ -15,13 +15,15 @@ if [ -z "$POD" ]; then
 fi
 
 echo "🔍 Verificando existencia de la base de datos '$DB_NAME'..."
-DB_EXISTS=$(kubectl exec -n $NAMESPACE "$POD" -- bash -c "psql -U \"$POSTGRES_USER\" -tAc \"SELECT 1 FROM pg_database WHERE datname = '$DB_NAME';\"")
+DB_EXISTS=$(kubectl exec -n "$NAMESPACE" "$POD" -- \
+  env DB_NAME="$DB_NAME" bash -c 'psql -U "$POSTGRES_USER" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname = '\''$DB_NAME'\'';"')
 
 if [ "$DB_EXISTS" = "1" ]; then
   echo "✅ La base de datos '$DB_NAME' ya existe."
 else
   echo "🆕 Creando base de datos '$DB_NAME'..."
-  kubectl exec -n $NAMESPACE "$POD" -- bash -c "psql -U \"$POSTGRES_USER\" -c \"CREATE DATABASE $DB_NAME;\""
+  kubectl exec -n "$NAMESPACE" "$POD" -- \
+    env DB_NAME="$DB_NAME" bash -c 'psql -U "$POSTGRES_USER" -d postgres -c "CREATE DATABASE \"$DB_NAME\";"'
   echo "✅ Base de datos '$DB_NAME' creada."
 fi
 

--- a/init-postgres-schema.sh
+++ b/init-postgres-schema.sh
@@ -15,12 +15,14 @@ if [ -z "$POD" ]; then
 fi
 
 echo "🔍 Verificando existencia de la base de datos '$DB_NAME'..."
-DB_EXISTS=$(kubectl exec -n $NAMESPACE "$POD" -- bash -c "psql -U \"$POSTGRES_USER\" -tAc \"SELECT 1 FROM pg_database WHERE datname = '$DB_NAME';\"")
+DB_EXISTS=$(kubectl exec -n "$NAMESPACE" "$POD" -- \
+  env DB_NAME="$DB_NAME" bash -c 'psql -U "$POSTGRES_USER" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname = '\''$DB_NAME'\'';"')
 
 if [ "$DB_EXISTS" = "1" ]; then
   echo "✅ La base de datos '$DB_NAME' ya existe."
 else
   echo "🆕 Creando base de datos '$DB_NAME'..."
-  kubectl exec -n $NAMESPACE "$POD" -- bash -c "psql -U \"$POSTGRES_USER\" -c \"CREATE DATABASE $DB_NAME;\""
+  kubectl exec -n "$NAMESPACE" "$POD" -- \
+    env DB_NAME="$DB_NAME" bash -c 'psql -U "$POSTGRES_USER" -d postgres -c "CREATE DATABASE \"$DB_NAME\";"'
   echo "✅ Base de datos '$DB_NAME' creada."
 fi


### PR DESCRIPTION
## Summary
- correctly reference POSTGRES_USER environment variable inside postgres pod
- connect using the default `postgres` database when checking or creating DB

## Testing
- `bash -n init-create-postgres-db.sh`
- `bash -n init-postgres-schema.sh`
